### PR TITLE
add support for AVM FRITZ!Box 7520

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains resources to build a second stage U-Boot bootloader for
    - fritz1200
    - fritz3000
    - fritz4040
+   - fritz7520
    - fritz7530
 
 3. The finished U-Boot will be placed in the root directory as `uboot-<boardname>.bin`.
@@ -58,6 +59,7 @@ Passive mode on.
 ### NAND-based
 This is compatible with the following models
 
+ - FRITZ!Box 7520
  - FRITZ!Box 7530
  - FRITZ!Repeater 1200
  - FRITZ!Repeater 3000

--- a/boards.cfg
+++ b/boards.cfg
@@ -208,6 +208,7 @@ integratorcp_cm946es         arm         arm946es    integrator          armltd 
 fritz1200		     arm	 armv7	     ipq40xx_cdp	 qcom		qca
 fritz3000		     arm	 armv7	     ipq40xx_cdp	 qcom		qca
 fritz4040		     arm	 armv7	     ipq40xx_cdp	 qcom		qca
+fritz7520		     arm	 armv7	     ipq40xx_cdp	 qcom		qca
 fritz7530		     arm	 armv7	     ipq40xx_cdp	 qcom		qca
 ipq40xx_cdp                  arm         armv7       ipq40xx_cdp         qcom           qca
 rt-ac58u		     arm	 armv7	     ipq40xx_cdp	 qcom		qca

--- a/fritz/fritz7520.dts
+++ b/fritz/fritz7520.dts
@@ -1,0 +1,70 @@
+/dts-v1/;
+
+/ {
+	#address-cells = <0x1>;
+	#size-cells = <0x1>;
+	model = "AVM FRITZ!Box 7520";
+	compatible = "qcom,ipq40xx";
+	interrupt-parent = <0x1>;
+
+	chosen {
+		bootargs-append = " clk_ignore_unused ";
+	};
+
+	soc {
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges;
+		compatible = "simple-bus";
+
+		qpic-nand@79b0000 {
+			compatible = "qcom,ebi2-nandc-bam", "qcom,msm-nand";
+			reg = < 0x79b0000 0x1000 >;
+			#address-cells = < 0x01 >;
+			#size-cells = < 0x00 >;
+			clocks = < 0x04 0x2d 0x04 0x2c >;
+			clock-names = "core", "aon";
+			dmas = < 0x14 0x00 0x14 0x01 0x14 0x02 >;
+			dma-names = "tx", "rx", "cmd";
+			status = "ok";
+
+			nandcs@0 {
+				compatible = "qcom,nandcs", "avm,nand_partitions";
+				reg = < 0x00 >;
+				#address-cells = < 0x01 >;
+				#size-cells = < 0x01 >;
+				nand-ecc-strength = < 0x04 >;
+				nand-ecc-step-size = < 0x200 >;
+				nand-bus-width = < 0x08 >;
+			};
+		};
+
+	};
+
+	reserved-memory {
+		#address-cells = <0x1>;
+		#size-cells = <0x1>;
+		ranges;
+
+		rsvd1@87000000 {
+			reg = <0x87000000 0x500000>;
+			no-map;
+		};
+
+		wifi_dump@87500000 {
+			reg = <0x87500000 0x600000>;
+			no-map;
+		};
+
+		rsvd2@87B00000 {
+			reg = <0x87b00000 0x500000>;
+			no-map;
+		};
+	};
+
+	avm-hw-revision {
+		compatible = "avm,avm_hw_revision";
+		revision = "247";
+		subrevision = [30 00];
+	};
+};

--- a/include/configs/fritz7520.h
+++ b/include/configs/fritz7520.h
@@ -1,0 +1,56 @@
+/*
+ * Configuration for the AVM Fritz!Box 7520
+ */
+
+#ifndef __CONFIG_H
+#define __CONFIG_H
+
+#include <configs/ipq40xx_cdp.h>
+
+#define CONFIG_MODEL_FRITZ7520
+#define CONFIG_MODEL		"FRITZ7520"
+#define MTDIDS_DEFAULT		"nand1=nand1"
+#define MTDPARTS_DEFAULT	"mtdparts=nand1:2816k(urlader)ro,8448k(nand-tffs)ro,4096k(kernel)ro,4096k(reserved-kernel)ro,111616k(ubi)"
+
+#undef CONFIG_BOOTDELAY
+#define CONFIG_BOOTDELAY 3
+
+#undef CONFIG_BOOTCOMMAND
+#define CONFIG_BOOTCOMMAND		"run fritzboot"
+
+#define CONFIG_EXTRA_ENV_SETTINGS				\
+	"mtdids=" MTDIDS_DEFAULT "\0"				\
+	"mtdparts=" MTDPARTS_DEFAULT "\0"			\
+	"nandboot=ubi part ubi && ubi read 0x85000000 kernel && bootm\0"	\
+	"tftpboot=tftpboot && bootm; sleep 5; run tftpboot\0"	\
+	"fritzboot=run nandboot || run tftpboot;\0"		\
+
+#undef V_PROMPT
+#define V_PROMPT		"(" CONFIG_MODEL ") # "
+
+#define CONFIG_AVM_QPIC_NAND
+#define CONFIG_AVM_EVA_MAC_EXTRACT
+#define CONFIG_AVM_EVA_CFG_OFFSET	0x2BE800
+
+#define CONFIG_SERVERIP         192.168.1.70
+#define CONFIG_NETMASK          255.255.255.0
+#define CONFIG_BOOTFILE         CONFIG_MODEL ".bin"
+#define CONFIG_LZO
+#define CONFIG_LZMA
+#define CONFIG_SYS_LONGHELP
+
+#define CONFIG_CMD_MISC
+#define CONFIG_CMD_ELF
+#define CONFIG_CMD_IMI
+#define CONFIG_CMD_LOADB
+#define CONFIG_CMD_SPI
+#define CONFIG_CMD_TFTPSRV
+
+#undef CONFIG_SYS_LOAD_ADDR
+#define CONFIG_SYS_LOAD_ADDR    0x85000000
+
+#undef CONFIG_SYS_TEXT_BASE
+#define CONFIG_SYS_TEXT_BASE	0x84200000
+
+#endif
+


### PR DESCRIPTION
The hardware is identical to the already supported 7530, the vendor firmware
just has artificial limitations.

Signed-off-by: Andre Heider <a.heider@gmail.com>