### PR TITLE
Add fixup for new NAND chip in FRITZ!7530

### DIFF
--- a/drivers/mtd/qpic_nand.c
+++ b/drivers/mtd/qpic_nand.c
@@ -1314,6 +1314,14 @@ static int qpic_nand_get_info(struct mtd_info *mtd, uint32_t flash_id)
 
 	dev->ecc_width = NAND_WITH_4_BIT_ECC;
 
+	if(man_id == 0x98 && dev_id == 0xf1 && cfg_id == 0x15) {
+		printf("=================================\n");
+		printf("Fixup for Toshiba TC58NVG0S3HTA00\n");
+		printf("=================================\n");
+		dev->ecc_width = NAND_WITH_8_BIT_ECC;
+		mtd->oobsize = dev->spare_size = 128;
+	}
+
 	dev->num_blocks = mtd->size;
 	dev->num_blocks /= (dev->block_size);
 	dev->num_pages_per_blk = dev->block_size / dev->page_size;


### PR DESCRIPTION
My new FRITZ!7530 contains a different NAND IC (KIOXIA/Toshiba TC58NVG0S3HTA00) that is not properly detected by the NAND driver. This fixup hardcodes the necessary parameters.

NB: The ECC width is still defined as 4 bit in the DTS, but I don't think that this is ever parsed.