### PR TITLE
Replace custom bool definitions with <stdbool.h>

### DIFF
--- a/arch/blackfin/include/asm/posix_types.h
+++ b/arch/blackfin/include/asm/posix_types.h
@@ -28,6 +28,8 @@
 #ifndef __ARCH_BLACKFIN_POSIX_TYPES_H
 #define __ARCH_BLACKFIN_POSIX_TYPES_H
 
+#include <stdbool.h>
+
 /*
  * This file is generally used by user-level software, so you need to
  * be a little careful about namespace pollution etc.  Also, we cannot
@@ -60,9 +62,6 @@ typedef unsigned int __kernel_gid32_t;
 
 typedef unsigned short __kernel_old_uid_t;
 typedef unsigned short __kernel_old_gid_t;
-
-#define BOOL_WAS_DEFINED
-typedef enum { false = 0, true = 1 } bool;
 
 #ifdef __GNUC__
 typedef long long __kernel_loff_t;

--- a/board/Marvell/include/core.h
+++ b/board/Marvell/include/core.h
@@ -13,6 +13,7 @@ space). The macros take care of Big/Little endian conversions.
 #define __INCcoreh
 
 #include "mv_gen_reg.h"
+#include <stdbool.h>
 
 extern unsigned int INTERNAL_REG_BASE_ADDR;
 
@@ -90,11 +91,6 @@ extern unsigned int INTERNAL_REG_BASE_ADDR;
 
 #define _1G		0x40000000
 #define _2G		0x80000000
-
-#ifndef	BOOL_WAS_DEFINED
-#define BOOL_WAS_DEFINED
-typedef enum _bool{false,true} bool;
-#endif
 
 /* Little to Big endian conversion macros */
 

--- a/drivers/usb/host/xhci.h
+++ b/drivers/usb/host/xhci.h
@@ -20,6 +20,7 @@
 #include <asm/cache.h>
 #include <asm/io.h>
 #include <linux/list.h>
+#include <stdbool.h>
 
 #define upper_32_bits(n) (u32)((n) >> 32)
 #define lower_32_bits(n) (u32)(n)
@@ -1200,11 +1201,6 @@ void xhci_hcd_stop(int index);
 
 /* true: Controller Not Ready to accept doorbell or op reg writes after reset */
 #define XHCI_STS_CNR		(1 << 11)
-
-#ifndef	BOOL_WAS_DEFINED
-#define BOOL_WAS_DEFINED
-typedef enum _bool{false,true} bool;
-#endif
 
 struct xhci_ctrl {
 	struct xhci_hccr *hccr;	/* R/O registers, not need for volatile */

--- a/include/galileo/core.h
+++ b/include/galileo/core.h
@@ -14,6 +14,7 @@ space). The macros take care of Big/Little endian conversions.
 
 /* includes */
 #include "gt64260R.h"
+#include <stdbool.h>
 
 extern unsigned int INTERNAL_REG_BASE_ADDR;
 
@@ -109,11 +110,6 @@ extern unsigned int INTERNAL_REG_BASE_ADDR;
 
 #define _1G             0x40000000
 #define _2G             0x80000000
-
-#ifndef	BOOL_WAS_DEFINED
-#define BOOL_WAS_DEFINED
-typedef enum _bool{false,true} bool;
-#endif
 
 /* Little to Big endian conversion macros */
 

--- a/include/xyzModem.h
+++ b/include/xyzModem.h
@@ -58,6 +58,8 @@
 #ifndef _XYZMODEM_H_
 #define _XYZMODEM_H_
 
+#include <stdbool.h>
+
 #define xyzModem_xmodem 1
 #define xyzModem_ymodem 2
 /* Don't define this until the protocol support is in place */
@@ -96,14 +98,6 @@ typedef struct {
     struct sockaddr_in *server;
 #endif
 } connection_info_t;
-
-#ifndef	BOOL_WAS_DEFINED
-#define BOOL_WAS_DEFINED
-typedef unsigned int bool;
-#endif
-
-#define false 0
-#define true 1
 
 #endif
 


### PR DESCRIPTION
There is the following compile error while building with `-std=gnu23`, which is now default for GCC 15:
```
In file included from cmd_load.c:32:
include/xyzModem.h:102:22: error: 'bool' cannot be defined via 'typedef'
  102 | typedef unsigned int bool;
      |                      ^~~~
include/xyzModem.h:102:22: note: 'bool' is a keyword with '-std=c23' onwards
```

This patch removes the manual bool definitions and includes `<stdbool.h>` instead.