### PR TITLE
Makefile: add missing generic asm-offsets dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -647,7 +647,8 @@ $(obj)include/generated/asm-offsets.h:	$(obj)include/autoconf.mk.dep \
 	@$(XECHO) Generating $@
 	tools/scripts/make-asm-offsets $(obj)$(CPUDIR)/$(SOC)/asm-offsets.s $@
 
-$(obj)$(CPUDIR)/$(SOC)/asm-offsets.s:	$(obj)include/autoconf.mk.dep
+$(obj)$(CPUDIR)/$(SOC)/asm-offsets.s:	$(obj)include/autoconf.mk.dep \
+	$(obj)include/generated/generic-asm-offsets.h
 	@mkdir -p $(obj)$(CPUDIR)/$(SOC)
 	if [ -f $(src)$(CPUDIR)/$(SOC)/asm-offsets.c ];then \
 		$(CC) -DDO_DEPS_ONLY -DDO_SOC_DEPS_ONLY \


### PR DESCRIPTION
The SoC asm-offsets pass compiles include/configs/ipq40xx_cdp.h with DO_SOC_DEPS_ONLY, which pulls in <generated/generic-asm-offsets.h> for GENERATED_GBL_DATA_SIZE. That header comes from a separate rule and the two rules only share the include/autoconf.mk.dep prerequisite, so a parallel make can run them at the same time:

  include/configs/ipq40xx_cdp.h:108:37: error: 'GENERATED_GBL_DATA_SIZE' undeclared here (not in a function)
  make[7]: *** [Makefile:652: arch/arm/cpu/armv7/qca/asm-offsets.s] Error 1

The build only breaks when both rules are scheduled together, which makes the failure intermittent.

Add the missing dependency.